### PR TITLE
Add docstrings and usage comments

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,8 @@
+"""Entrypoint for running the FastAPI server."""
+
 from src import server
 
 if __name__ == "__main__":
+    # Launch the FastAPI application
     server.run()
     

--- a/naive_bayse/app.py
+++ b/naive_bayse/app.py
@@ -7,34 +7,36 @@ from src.evaluator import Evaluator
 
 class App:
     def __init__(self):
-        """
-        Initialize the App with no loaded data or target column.
-        """
+        """Initialize the App with no loaded data or target column."""
         self.classifier = NaiveBayesClassifier()
         self.train_df = None
         self.test_df = None
         self.target_column = None
 
     def list_available_files(self):
-        """
-        List all CSV files available in the Data directory.
+        """List all CSV files available in the Data directory.
 
         Returns:
             List[str]: A list of CSV file names.
+
+        Usage:
+            files = app.list_available_files()
         """
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         data_dir = os.path.join(BASE_DIR, "Data")
         return [f for f in os.listdir(data_dir) if f.endswith('.csv')]
 
     def load_and_clean(self, selected_file_name):
-        """
-        Load the selected CSV file, clean it and split into train/test.
+        """Load the selected CSV file, clean it and split into train/test.
 
         Args:
             selected_file_name (str): Name of the CSV file to load.
 
         Returns:
             dict: Status message and list of column names.
+
+        Usage:
+            app.load_and_clean("data.csv")
         """
         BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         data_dir = os.path.join(BASE_DIR, "Data")
@@ -50,14 +52,16 @@ class App:
         return {"status": "success", "columns": self.train_df.columns.tolist()}
 
     def set_target_column(self, column_name):
-        """
-        Set the target column to be used as labels for training and prediction.
+        """Set the target column to be used as labels for training and prediction.
 
         Args:
             column_name (str): Name of the column to use as target.
 
         Returns:
             dict: Status message with the selected target column.
+
+        Usage:
+            app.set_target_column("label")
         """
         if self.train_df is None:
             raise ValueError("No data loaded yet.")
@@ -67,11 +71,13 @@ class App:
         return {"status": "success", "target_column": self.target_column}
 
     def get_features_with_values(self):
-        """
-        Get all feature columns (excluding the target) with their unique possible values.
+        """Get all feature columns (excluding the target) with their unique possible values.
 
         Returns:
             dict: Mapping from feature name to list of unique values.
+
+        Usage:
+            features = app.get_features_with_values()
         """
         if self.train_df is None:
             raise ValueError("No training data loaded.")
@@ -85,11 +91,13 @@ class App:
         return features
 
     def train_model(self):
-        """
-        Train the Naive Bayes classifier on the loaded training data.
+        """Train the Naive Bayes classifier on the loaded training data.
 
         Returns:
             dict: Status message.
+
+        Usage:
+            app.train_model()
         """
         if self.train_df is None:
             raise ValueError("No training data loaded.")
@@ -99,11 +107,13 @@ class App:
         return {"status": "success", "message": "Model trained successfully."}
 
     def evaluate_model(self):
-        """
-        Evaluate the trained model using the test dataset.
+        """Evaluate the trained model using the test dataset.
 
         Returns:
             dict: Accuracy score.
+
+        Usage:
+            app.evaluate_model()
         """
         if self.test_df is None:
             raise ValueError("No test data loaded.")
@@ -114,14 +124,16 @@ class App:
         return {"accuracy": accuracy}
 
     def classify_record(self, record: dict):
-        """
-        Classify a new record using the trained model.
+        """Classify a new record using the trained model.
 
         Args:
             record (dict): Dictionary of feature values.
 
         Returns:
             dict: Prediction result.
+
+        Usage:
+            result = app.classify_record(record)
         """
         if self.train_df is None:
             raise ValueError("No data loaded.")

--- a/naive_bayse/data_loader.py
+++ b/naive_bayse/data_loader.py
@@ -1,19 +1,35 @@
 import pandas as pd
 
 class DataLoader:
+    """Helpers for loading various data formats."""
+
     @staticmethod
     def load_data(file_path):
+        """Load a CSV file.
+
+        Args:
+            file_path (str): Path to the CSV file.
+
+        Returns:
+            pandas.DataFrame: Loaded DataFrame.
+
+        Usage:
+            df = DataLoader.load_data("data.csv")
+        """
         return pd.read_csv(file_path)
 
     @staticmethod
     def load_json(file_path):
+        """Load a JSON file into a DataFrame."""
         return pd.read_json(file_path)
 
     @staticmethod
     def load_excel(file_path):
+        """Load an Excel file into a DataFrame."""
         return pd.read_excel(file_path)
 
     @staticmethod
     def load_from_df(df: pd.DataFrame):
+        """Return the provided DataFrame as is."""
         return df
 

--- a/naive_bayse/data_procesor.py
+++ b/naive_bayse/data_procesor.py
@@ -2,10 +2,25 @@ from sklearn.model_selection import train_test_split
 import pandas as pd
 
 class DataProcessor:
+    """Utility class for preprocessing datasets."""
+
     def __init__(self, df):
+        """Store a DataFrame for later processing.
+
+        Args:
+            df (pandas.DataFrame): Raw data.
+        """
         self.df = df
 
     def clean_data(self):
+        """Remove rows with missing values.
+
+        Returns:
+            pandas.DataFrame: Cleaned DataFrame.
+
+        Usage:
+            cleaned = processor.clean_data()
+        """
         self.df.dropna(inplace=True)
         return self.df
 
@@ -40,5 +55,19 @@ class DataProcessor:
     #     return pd.Series(dtype=float)
 
     def split_data(self, train_size=0.7, random_state=42):
-        train_df, test_df = train_test_split(self.df, train_size=train_size, random_state=random_state)
+        """Split the dataset into train and test parts.
+
+        Args:
+            train_size (float): Fraction of data to use for training.
+            random_state (int): Random seed for reproducibility.
+
+        Returns:
+            Tuple[pandas.DataFrame, pandas.DataFrame]: Train and test sets.
+
+        Usage:
+            train_df, test_df = processor.split_data()
+        """
+        train_df, test_df = train_test_split(
+            self.df, train_size=train_size, random_state=random_state
+        )
         return train_df, test_df

--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -1,21 +1,53 @@
 class Evaluator:
+    """Utility class for evaluating classifier performance."""
+
     def evaluate_sample(self, classifier, record, true_label):
+        """Evaluate a single classification.
+
+        Args:
+            classifier (NaiveBayesClassifier): Trained classifier.
+            record (dict): Feature values to classify.
+            true_label (str): Expected label for the record.
+
+        Returns:
+            bool: ``True`` if prediction matches ``true_label``.
+
+        Usage:
+            evaluator.evaluate_sample(clf, sample, "yes")
+        """
         predicted = classifier.classify(record)
         if predicted == true_label:
             print(f"Correctly classified: {record} as {predicted}")
             return True
         else:
-            print(f"Incorrectly classified: {record} as {predicted}, expected {true_label}")
+            print(
+                f"Incorrectly classified: {record} as {predicted}, expected {true_label}"
+            )
             return False
 
     def evaluate(self, classifier, test_df, target_column):
+        """Evaluate classifier accuracy on a dataset.
+
+        Args:
+            classifier (NaiveBayesClassifier): Trained classifier.
+            test_df (pandas.DataFrame): Dataset containing features and labels.
+            target_column (str): Name of the label column.
+
+        Returns:
+            float: Classification accuracy as a value between 0 and 1.
+
+        Usage:
+            accuracy = evaluator.evaluate(clf, df_test, "label")
+        """
         correct_predictions = 0
         total_predictions = len(test_df)
-        for index, row in test_df.iterrows():
+        for _, row in test_df.iterrows():
             record = row.drop(target_column).to_dict()
             predicted = classifier.classify(record)
             if predicted == row[target_column]:
                 correct_predictions += 1
         accuracy = correct_predictions / total_predictions
-        print(f"Accuracy: {correct_predictions}/{total_predictions} ({(correct_predictions / total_predictions) * 100:.2f}%)")
+        print(
+            f"Accuracy: {correct_predictions}/{total_predictions} ({(correct_predictions / total_predictions) * 100:.2f}%)"
+        )
         return accuracy

--- a/src/naive_bayes_classifier.py
+++ b/src/naive_bayes_classifier.py
@@ -1,13 +1,28 @@
 class NaiveBayesClassifier:
+    """Simple categorical Naive Bayes classifier."""
+
     def __init__(self):
+        """Initialize empty model structures."""
+        # Stores conditional probabilities for each feature value
         self.model = {}
+        # Prior probabilities for each class
         self.priors = {}
+        # List of possible class labels
         self.classes = []
 
 
     def fit(self, df, target_column):
+        """Train the classifier.
+
+        Args:
+            df (pandas.DataFrame): The full dataset including the target.
+            target_column (str): Name of the label column.
+
+        Usage:
+            classifier.fit(training_df, "label")
+        """
         target_variable = df[target_column]
-        feature_cols = df.drop(columns=[target_column],axis=1)
+        feature_cols = df.drop(columns=[target_column], axis=1)
         self.classes = target_variable.unique()
         self.priors = df[target_column].value_counts(normalize=True).to_dict()
 
@@ -29,6 +44,17 @@ class NaiveBayesClassifier:
 
 
     def classify(self, record):
+        """Classify a single record.
+
+        Args:
+            record (dict): Mapping of feature names to values.
+
+        Returns:
+            str: Predicted class label.
+
+        Usage:
+            label = classifier.classify({"age": "30", "gender": "M"})
+        """
         prob_yes = self.priors[self.classes[0]]
         prob_no = self.priors[self.classes[1]]
 

--- a/src/server.py
+++ b/src/server.py
@@ -20,18 +20,22 @@ class RecordRequest(BaseModel):
 
 @app.get("/")
 async def root():
-    """
-    Root endpoint to verify that the API is running.
+    """Root endpoint to verify that the API is running.
+
+    Usage:
+        curl http://localhost:8000/
     """
     return {"message": "Welcome to the Naive Bayes Classifier API"}
 
 @app.get("/available_files")
 async def available_files():
-    """
-    Get a list of available CSV files.
+    """Get a list of available CSV files.
 
     Returns:
         dict: List of file names.
+
+    Usage:
+        curl http://localhost:8000/available_files
     """
     files = data_app.list_available_files()
     if not files:
@@ -40,13 +44,16 @@ async def available_files():
 
 @app.post("/load_file")
 async def load_file(req: FileRequest):
-    """
-    Load the selected file and return available columns.
+    """Load the selected file and return available columns.
 
     Args:
         req (FileRequest): Request containing file_name.
     Returns:
         dict: Status and list of columns.
+
+    Usage:
+        curl -X POST -H "Content-Type: application/json" \
+            -d '{"file_name": "data.csv"}' http://localhost:8000/load_file
     """
     try:
         result = data_app.load_and_clean(req.file_name)
@@ -58,14 +65,17 @@ async def load_file(req: FileRequest):
 
 @app.post("/set_target_column")
 async def set_target_column(req: LabelRequest):
-    """
-    Set the target column for labels.
+    """Set the target column for labels.
 
     Args:
         req (LabelRequest): Request containing target_column.
 
     Returns:
         dict: Status message.
+
+    Usage:
+        curl -X POST -H "Content-Type: application/json" \
+            -d '{"target_column": "label"}' http://localhost:8000/set_target_column
     """
     try:
         result = data_app.set_target_column(req.target_column)
@@ -75,11 +85,13 @@ async def set_target_column(req: LabelRequest):
 
 @app.get("/features")
 async def get_features():
-    """
-    Get feature columns (excluding target) with unique values.
+    """Get feature columns (excluding target) with unique values.
 
     Returns:
         dict: Mapping from feature names to unique values.
+
+    Usage:
+        curl http://localhost:8000/features
     """
     try:
         return data_app.get_features_with_values()
@@ -88,11 +100,13 @@ async def get_features():
 
 @app.post("/train")
 async def train_model():
-    """
-    Train the model using the selected target column.
+    """Train the model using the selected target column.
 
     Returns:
         dict: Status message.
+
+    Usage:
+        curl -X POST http://localhost:8000/train
     """
     try:
         return data_app.train_model()
@@ -101,11 +115,13 @@ async def train_model():
 
 @app.get("/accuracy")
 async def get_accuracy():
-    """
-    Get the accuracy of the trained model.
+    """Get the accuracy of the trained model.
 
     Returns:
         dict: Accuracy score.
+
+    Usage:
+        curl http://localhost:8000/accuracy
     """
     try:
         return data_app.evaluate_model()
@@ -114,14 +130,17 @@ async def get_accuracy():
 
 @app.post("/predict")
 async def predict(req: RecordRequest):
-    """
-    Predict the class of a new record.
+    """Predict the class of a new record.
 
     Args:
         req (RecordRequest): Request containing record dictionary.
 
     Returns:
         dict: Prediction result.
+
+    Usage:
+        curl -X POST -H "Content-Type: application/json" \
+            -d '{"record": {"feature": "value"}}' http://localhost:8000/predict
     """
     try:
         return data_app.classify_record(req.record)

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -1,8 +1,16 @@
 from naive_bayse.app import App
 
+
 class Menu:
+    """Simple CLI menu for interacting with :class:`App`."""
 
     def display(self):
+        """Show the menu loop until the user exits.
+
+        Usage:
+            menu = Menu()
+            menu.display()
+        """
         while True:
             print("\n--- Naive Bayes Classifier Menu ---")
             print("1. Load & clean data")


### PR DESCRIPTION
## Summary
- document NaiveBayesClassifier internals and usage
- add evaluator and preprocessing docs
- clarify data loading helpers
- expand App API docs with usage guidance
- document CLI menu and API endpoints
- add module docstring in main

## Testing
- `python3 -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_687791f8ce84832dab37213feea65b71