### PR TITLE
Add model persistence support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Naive Bayes Classifier API
+
+This project exposes a simple Naive Bayes classifier via FastAPI. Models are automatically saved after training to `model.pkl` in the project root. You can reload a saved model using the `/load_model` endpoint.
+
+## Usage
+
+1. **Train and Save**
+   ```bash
+   curl -X POST http://localhost:8000/train
+   ```
+   Training stores the classifier in `model.pkl`.
+
+2. **Load a Saved Model**
+   ```bash
+   curl -X POST -H "Content-Type: application/json" \
+        -d '{"path": "model.pkl"}' http://localhost:8000/load_model
+   ```
+
+The saved file `model.pkl` resides in the repository's base directory.

--- a/src/server.py
+++ b/src/server.py
@@ -18,6 +18,9 @@ class LabelRequest(BaseModel):
 class RecordRequest(BaseModel):
     record: dict
 
+class PathRequest(BaseModel):
+    path: str
+
 @app.get("/")
 async def root():
     """Root endpoint to verify that the API is running.
@@ -100,7 +103,7 @@ async def get_features():
 
 @app.post("/train")
 async def train_model():
-    """Train the model using the selected target column.
+    """Train the model using the selected target column and save it to ``model.pkl``.
 
     Returns:
         dict: Status message.
@@ -144,6 +147,27 @@ async def predict(req: RecordRequest):
     """
     try:
         return data_app.classify_record(req.record)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.post("/load_model")
+async def load_model(req: PathRequest):
+    """Load a previously saved classifier from disk.
+
+    Args:
+        req (PathRequest): Path to the pickle file.
+
+    Returns:
+        dict: Status message.
+
+    Usage:
+        curl -X POST -H "Content-Type: application/json" \
+            -d '{"path": "model.pkl"}' http://localhost:8000/load_model
+    """
+    try:
+        return data_app.load_model(req.path)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 


### PR DESCRIPTION
## Summary
- save trained classifier to `model.pkl`
- support loading a saved model in `App`
- expose `/load_model` endpoint
- document model file location and usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

